### PR TITLE
chore(env): Update conda environment dependencies

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -11,5 +11,6 @@ dependencies:
   - torchaudio=0.12.1
   - torchvision=0.13.1
   - tqdm=4.65.0
-  - open3d=0.16.0
   - Pillow=9.4.0
+  - pip:
+    - open3d==0.16.0


### PR DESCRIPTION
- Added missing channels for package resolution.
- Specified available versions for some packages.
- Moved open3d installation to pip due to unavailable version in conda channels.